### PR TITLE
Update success colors in StepIndicator

### DIFF
--- a/components/booking/StepIndicator.tsx
+++ b/components/booking/StepIndicator.tsx
@@ -40,7 +40,7 @@ export const StepIndicator = ({ currentStep, totalSteps, steps }: StepIndicatorP
                   isActive
                     ? 'text-brand-primary'
                     : isCompleted
-                    ? 'text-brand-success'
+                    ? 'text-success-green'
                     : 'text-gray-400'
               }`}
             >
@@ -49,7 +49,7 @@ export const StepIndicator = ({ currentStep, totalSteps, steps }: StepIndicatorP
                   isActive
                     ? 'bg-brand-primary'
                     : isCompleted
-                    ? 'bg-brand-success'
+                    ? 'bg-success-green-light'
                     : 'bg-gray-300'
                 }`}
               />


### PR DESCRIPTION
## Summary
- use `text-success-green` for completed step text
- use `bg-success-green-light` for completed step dots

## Testing
- `npm run lint` *(fails: getServiceBadgeClass assigned value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5f77520833082490e2740134924