### PR TITLE
Fix footer email formatting

### DIFF
--- a/components/booking/BookingConfirmation.tsx
+++ b/components/booking/BookingConfirmation.tsx
@@ -157,8 +157,8 @@ export const BookingConfirmation = ({ booking, onBookAnother }: BookingConfirmat
         {/* Footer Message */}
         <div className="mt-12 text-center">
           <p className="text-gray-400 text-sm">
-            Questions? Call us at <span className="font-medium text-primary-gold">(615) 555-FADE</span> or email 
-            <span className="font-medium text-primary-gold"> hello@fadeclub.com</span>
+            Questions? Call us at <span className="font-medium text-primary-gold">(615) 555-FADE</span> or email
+            <span className="font-medium text-primary-gold">hello@fadeclub.com</span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove leading space from email address in BookingConfirmation footer

## Testing
- `npm run lint` *(fails: unused variables in admin components)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5f843b48330bd1372faccd0ea93