### PR TITLE
Add type-check script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ npm run build
 ```
 
 ### Type Checking
+Run the TypeScript compiler without emitting files:
 ```bash
 npm run type-check
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "next": "15.3.5",


### PR DESCRIPTION
## Summary
- add a `type-check` npm script using `tsc --noEmit`
- document the new script in README

## Testing
- `npm run lint` *(fails: getServiceBadgeClass not used)*
- `npm run build` *(fails during ESLint step)*
- `npm run type-check` *(fails: Booking type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5f92c448330901da57caac388b3